### PR TITLE
Bug 109089: Ignore trailing spaces for zimbraMtaBlockedExtension

### DIFF
--- a/conf/amavisd.conf.in
+++ b/conf/amavisd.conf.in
@@ -267,7 +267,7 @@ $archive_quarantine_to = undef;
 
 $banned_filename_re = new_RE(
   # banned extension - basic
-  %%uncomment VAR:zimbraMtaBlockedExtension%%qr'.\.(%%list VAR:zimbraMtaBlockedExtension |%%)$'i,
+  %%uncomment VAR:zimbraMtaBlockedExtension%%qr{.\.(?:%%list VAR:zimbraMtaBlockedExtension |%%)\s*$}i,
 ### BLOCKED ANYWHERE
 # qr'^UNDECIPHERABLE$',  # is or contains any undecipherable components
 #  qr'^\.(exe-ms|dll)$',                   # banned file(1) types, rudimentary


### PR DESCRIPTION
There are currently some trojans sent around with filenames which end in spaces.  These files aren't caught by `zimbraMtaBlockedExtension` but the target system happily strips off the spaces and makes the file available to the user.