### PR TITLE
ZBUG-1919: added amavis_sslversion to configure sslversion for amavis

### DIFF
--- a/conf/amavisd.conf.in
+++ b/conf/amavisd.conf.in
@@ -26,6 +26,7 @@ $default_ldap = {
 	hostname      => [ split (' ','@@ldap_url@@') ],
 	timeout       => 30,
 	tls           => @@ldap_starttls_supported@@,
+	sslversion    => '@@amavis_sslversion@@',
 	query_filter  => '(&(objectClass=amavisAccount)(zimbraMailStatus=enabled)(|(mail=%m)(zimbraDomainName=%m)))',
 	bind_dn       => 'uid=zmamavis,cn=appaccts,cn=zimbra',
 	bind_password => '@@ldap_amavis_password@@',


### PR DESCRIPTION
**Problem:**

"$ zmlocalconfig -e ldap_common_tlsprotocolmin=3.2" will set olcTLSProtocolMin to 3.2 in LDAP config.

olcTLSProtocolMin: 3.2 would require TLS 1.1 but amavisd by default use tlsv1, due to this amavisd not able to establish connection with ldap.

**ldap debug log**: TLS: can't accept: error:14209102:SSL routines:tls_early_post_process_client_hello:unsupported protocol.

`60791147 daemon: epoll: listen=7 active_threads=0 tvp=zero
60791147 daemon: epoll: listen=8 active_threads=0 tvp=zero
60791147 daemon: activity on 1 descriptor
60791147 daemon: activity on: 23r
60791147 daemon: read active on 23
60791147 daemon: epoll: listen=7 active_threads=0 tvp=zero
60791147 daemon: epoll: listen=8 active_threads=0 tvp=zero
TLS: can't accept: error:14209102:SSL routines:tls_early_post_process_client_hello:unsupported protocol.
60791147 connection_closing: readying conn=1021 sd=23 for close
60791147 daemon: activity on 1 descriptor
`

**Approach to fix:**

need to disable TLSv1 in amavisd because olcTLSProtocolMin:3.2 would require TLS 1.1

$ zmlocalconfig -e amavis_sslversion='!TLSv1'

add "sslversion => @@amavis_sslversion@@" in /opt/zimbra/conf/amavisd.conf.in



**Reference:**

check olcTLSProtocolMin in https://www.openldap.org/software/man.cgi?query=slapd-config&sektion=5&apropos=0&manpath=OpenLDAP+2.4-Release

check sslversion in https://fossies.org/linux/amavisd-new/README_FILES/README.ldap

check SSL_version in https://metacpan.org/pod/IO::Socket::SSL

